### PR TITLE
docs: add calmmm demo deck plan

### DIFF
--- a/docs/superpowers/plans/2026-06-29-calmmm-demo-deck.md
+++ b/docs/superpowers/plans/2026-06-29-calmmm-demo-deck.md
@@ -1,0 +1,40 @@
+# calmmm Demo Deck Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an editable PowerPoint walkthrough and synthetic sample data for the `calmmm` package.
+
+**Architecture:** Generate deterministic synthetic CSV inputs, then build a seven-slide editable PowerPoint with `@oai/artifact-tool`. Render slide previews and inspect the final deck before delivery.
+
+**Tech Stack:** Node.js ES modules, `@oai/artifact-tool`, local repository docs, synthetic CSV files.
+
+---
+
+### Task 1: Generate Data And Deck
+
+**Files:**
+- Create: `outputs/calmmm_sample_weekly_panel.csv`
+- Create: `outputs/calmmm_sample_lift_tests.csv`
+- Create: `outputs/calmmm_demo_walkthrough.pptx`
+- Create: external scratch builder under the presentation workspace
+- Modify: `.agents/MEMORY.md`
+
+- [ ] **Step 1: Generate deterministic sample data**
+
+Create weekly panel rows for 78 weeks, 4 geos, 4 media channels, 4 KPIs, and realistic controls. Create lift-test rows for search and direct-mail experiments.
+
+- [ ] **Step 2: Build the PowerPoint**
+
+Use `@oai/artifact-tool` from a presentation scratch workspace. Create seven editable slides that match the approved design.
+
+- [ ] **Step 3: Render and inspect**
+
+Render all slides to PNG and a montage. Inspect layout JSON and previews for visible defects.
+
+- [ ] **Step 4: Update project memory**
+
+Append an `[OUTCOMES]` entry to `.agents/MEMORY.md` with generated artifact paths and verification status.
+
+- [ ] **Step 5: Final response**
+
+Return the final PPTX path and sample data paths.

--- a/docs/superpowers/specs/2026-06-29-calmmm-demo-deck-design.md
+++ b/docs/superpowers/specs/2026-06-29-calmmm-demo-deck-design.md
@@ -1,0 +1,39 @@
+# calmmm Demo Deck Design
+
+## Goal
+
+Create an editable PowerPoint walkthrough that explains the `calmmm` package end to end using synthetic credit-marketing data.
+
+## Deliverables
+
+- `outputs/calmmm_demo_walkthrough.pptx`: editable PowerPoint deck.
+- `outputs/calmmm_sample_weekly_panel.csv`: synthetic weekly panel data used by the deck.
+- `outputs/calmmm_sample_lift_tests.csv`: synthetic incrementality experiment table used by the deck.
+
+## Audience
+
+Analytics, data science, or stakeholder reviewers who need to understand what the package does, what inputs it expects, and what outputs it produces.
+
+## Content
+
+The deck will use seven slides:
+
+1. `calmmm` package overview.
+2. Synthetic weekly panel data: weeks, geos, media channels, KPIs, controls.
+3. End-to-end workflow: dataframe to `MMMData`, experiments, fit, outputs.
+4. Calibration example: search geo-holdout lift test.
+5. Model fit and validation: holdout metrics and posterior diagnostics.
+6. Attribution outputs: contribution, marginal contribution, ROI, saturation.
+7. How to run the package on real data.
+
+## Visual Direction
+
+Use a clean, editable PowerPoint style based on the bundled Codex Grid layout system: white canvas, black typography, light-gray structure, and one orange highlight. Use native text boxes, tables, simple process shapes, and charts rather than rasterized screenshots.
+
+## Data Scope
+
+The sample data will be synthetic and non-sensitive. It will represent a weekly credit-acquisition funnel with geographies, search/social/direct-mail/affiliate spend, impressions or clicks where relevant, price index, approval-rate proxy, visits, applications, approvals, and funded revenue.
+
+## Verification
+
+Render every final slide to image previews and inspect for clipping, overlap, unreadable text, broken charts, or unresolved placeholders. Export only after the deck renders cleanly.


### PR DESCRIPTION
## Summary
- Add the approved demo deck design spec.
- Add the implementation plan for generating the calmmm demo artifacts.

## Impact
This gives reviewers a small documentation-only branch explaining the walkthrough artifact scope before reviewing data or binary deck outputs.

## Validation
- Verified branch diff contains only the two docs/superpowers files.
