### PR TITLE
fix: update pytensor scan usage

### DIFF
--- a/calmmm/model/transforms.py
+++ b/calmmm/model/transforms.py
@@ -24,12 +24,11 @@ def geometric_adstock_pt(X, decay):
         return x_t + h_prev * decay_[None, :]
 
     h0 = pt.zeros_like(X[0])  # [G, C]
-    h_seq = pytensor.scan(
+    h_seq, _updates = pytensor.scan(
         _step,
         sequences=[X],
         outputs_info=[h0],
         non_sequences=[decay],
-        return_updates=False,
     )
     return h_seq  # [T, G, C]
 


### PR DESCRIPTION
## Summary
- Update geometric adstock to unpack pytensor.scan return values instead of using the removed return_updates argument.

## Validation
- PYTENSOR_FLAGS='cxx=' uv run python -m pytest tests/model/test_transforms.py -q -p no:cacheprovider
- PYTENSOR_FLAGS='cxx=' uv run python -m pytest -q -p no:cacheprovider