### PR TITLE
feat: add spend response report

### DIFF
--- a/calmmm/attribution/curves.py
+++ b/calmmm/attribution/curves.py
@@ -46,6 +46,57 @@ def saturation_curve(fit: "MMMFit", channel: str, n_points: int = 50) -> pd.Data
     return pd.DataFrame({"spend": x, "saturation": saturation, "channel": channel})
 
 
+def spend_response_report(
+    fit: "MMMFit",
+    panel: pd.DataFrame,
+    *,
+    spend_columns: dict[str, str],
+    spend_multiplier: float = 1.10,
+    n_points: int = 100,
+) -> pd.DataFrame:
+    """
+    Summarize modeled saturation response for an increased-spend scenario.
+
+    Uses ``saturation_curve`` as the model-level primitive, then interpolates each
+    channel's fitted curve at current average spend and at
+    ``current_average_spend * spend_multiplier``.
+    """
+    rows = []
+    for channel in fit.data.channels:
+        spend_col = spend_columns.get(channel)
+        if spend_col is None or spend_col not in panel.columns:
+            continue
+
+        curve = saturation_curve(fit, channel=channel, n_points=n_points).sort_values("spend")
+        current_spend = float(panel[spend_col].mean())
+        increased_spend = current_spend * spend_multiplier
+        current_response = float(
+            np.interp(current_spend, curve["spend"], curve["saturation"])
+        )
+        increased_response = float(
+            np.interp(increased_spend, curve["spend"], curve["saturation"])
+        )
+        response_lift = increased_response - current_response
+        response_lift_pct = (
+            response_lift / current_response if current_response != 0 else np.nan
+        )
+
+        rows.append(
+            {
+                "channel": channel,
+                "spend_multiplier": spend_multiplier,
+                "current_spend": current_spend,
+                "increased_spend": increased_spend,
+                "current_response": current_response,
+                "increased_response": increased_response,
+                "response_lift": response_lift,
+                "response_lift_pct": response_lift_pct,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
 def _eval_hill_params(fit):
     """Return (hill_alpha [C], hill_k [C]) as numpy arrays."""
     if fit.map_params is not None:

--- a/tests/attribution/test_curves.py
+++ b/tests/attribution/test_curves.py
@@ -1,6 +1,63 @@
 import numpy as np
 import pytest
-from calmmm.attribution.curves import saturation_curve
+import pandas as pd
+
+from calmmm.attribution.curves import saturation_curve, spend_response_report
+
+
+class _FakeData:
+    channels = ["search", "social"]
+
+
+class _FakeFit:
+    data = _FakeData()
+
+
+def test_spend_response_report_uses_saturation_curves(monkeypatch):
+    def fake_saturation_curve(_fit, channel, n_points=100):
+        curves = {
+            "search": pd.DataFrame(
+                {
+                    "channel": ["search", "search"],
+                    "spend": [0.0, 400.0],
+                    "saturation": [0.0, 0.8],
+                }
+            ),
+            "social": pd.DataFrame(
+                {
+                    "channel": ["social", "social"],
+                    "spend": [0.0, 200.0],
+                    "saturation": [0.0, 0.5],
+                }
+            ),
+        }
+        return curves[channel]
+
+    monkeypatch.setattr(
+        "calmmm.attribution.curves.saturation_curve",
+        fake_saturation_curve,
+    )
+    panel = pd.DataFrame(
+        {
+            "search_spend": [100.0, 300.0],
+            "social_spend": [50.0, 150.0],
+        }
+    )
+
+    report = spend_response_report(
+        _FakeFit(),
+        panel,
+        spend_columns={"search": "search_spend", "social": "social_spend"},
+        spend_multiplier=1.10,
+    )
+
+    search = report.set_index("channel").loc["search"]
+    assert search["current_spend"] == 200.0
+    assert round(search["increased_spend"], 6) == 220.0
+    assert search["current_response"] == 0.4
+    assert round(search["increased_response"], 6) == 0.44
+    assert round(search["response_lift"], 6) == 0.04
+    assert round(search["response_lift_pct"], 6) == 0.10
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- Add spend_response_report using existing saturation curves as the model primitive.
- Add focused attribution coverage for current-vs-increased spend response.

## Validation
- PYTENSOR_FLAGS='cxx=' uv run python -m pytest tests/attribution/test_curves.py -q -p no:cacheprovider
- PYTENSOR_FLAGS='cxx=' uv run python -m pytest -q -p no:cacheprovider