### PR TITLE
chore: ignore uv lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .agents/
 .serena/
+uv.lock


### PR DESCRIPTION
## Summary
- Add uv.lock to .gitignore so local uv-generated lockfiles do not appear as untracked changes.

## Validation
- Not run; ignore-only change.