### PR TITLE
Fix hatchling wheel build: add missing package config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=7.4", "pytest-cov>=4.0"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["calmmm"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## Summary
- `pip install -e .` / `uv pip install -e .` fails with `ValueError: Unable to determine which files to ship inside the wheel` because hatchling can't infer the package location without explicit config.
- Adds `[tool.hatch.build.targets.wheel] packages = ["calmmm"]` to `pyproject.toml` so editable and wheel installs work.

## Test plan
- [x] `uv pip install -e .` succeeds and builds the wheel
- [x] `python -c "import calmmm; print(calmmm.HierarchicalMMM)"` resolves correctly
- [x] Fast test suite passes (`pytest -m "not slow"`)