### PR TITLE
Add GitHub Actions CI to run pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=7.4", "pytest-cov>=4.0"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["calmmm"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml`: runs the pytest suite on Python 3.11 for every push to `main` and every pull request.
- Fast suite only (`pyproject.toml`'s existing `addopts = "-m 'not slow'"` already deselects the PyMC-inference `slow` tests, so CI stays quick).

## Notes
- This branch is stacked on `fix/hatch-wheel-packages` (#21), since CI needs that fix to actually install the package. Diff will shrink to just the workflow file once #21 merges.

## Test plan
- [x] Verified the exact install + test steps in a clean venv locally: `pip install -e ".[dev]"` then `pytest -v` → 174 passed, 46 deselected